### PR TITLE
feat: Add TCP server to handle incoming logs from Logstash

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,12 +1,14 @@
 import express, { Request, Response } from 'express';
+import net from 'net';
 
 const app = express();
 const port = 3000;
+const tcpPort = 5000;  // Port to receive logs from Logstash
 
 // Middleware to parse JSON request bodies
 app.use(express.json());
 
-// Echo endpoint that responds with request details
+// Echo HTTP endpoint that responds with request details
 app.all('*', (req: Request, res: Response) => {
   res.json({
     method: req.method,
@@ -16,7 +18,37 @@ app.all('*', (req: Request, res: Response) => {
   });
 });
 
-// Start the server
+// Start the HTTP server
 app.listen(port, () => {
-  console.log(`Log Streamer service running at http://localhost:${port}`);
+  console.log(`HTTP Test server running at http://localhost:${port}`);
+});
+
+
+// ==================================//
+// ==================================//
+// ==================================//
+
+// Create a TCP server to receive logs
+const tcpServer = net.createServer((socket) => {
+  console.log('TCP client connected');
+
+  // Handle incoming data (log messages)
+  socket.on('data', (data) => {
+    try {
+      const logMessage = JSON.parse(data.toString());
+      console.log('Received log:', logMessage);
+    } catch (error) {
+      console.error('Error parsing log data:', error);
+    }
+  });
+
+  // Handle client disconnects
+  socket.on('end', () => {
+    console.log('TCP client disconnected');
+  });
+});
+
+// Start listening on the TCP port
+tcpServer.listen(tcpPort, '0.0.0.0', () => {
+  console.log(`TCP server listening on port ${tcpPort}`);
 });


### PR DESCRIPTION
- Integrated a TCP server using the  module to listen on port 5000.
- The TCP server parses incoming log data (in JSON format) and prints it to the console.
- Kept the existing Express HTTP server running on port 3000.
- Ensured the TCP server supports connections from Logstash for real-time log forwarding.